### PR TITLE
Improve robustness of simulation time calculation.

### DIFF
--- a/index.html
+++ b/index.html
@@ -113,6 +113,7 @@
 
       var particleCount = getQueryValue('particleCount', 500000);
       var pointSize = getQueryValue('pointSize', 1);
+      var skipRemainder = getQueryValue('skipRemainder', 0);
 
       var INT_MAX = 2147483647;
 
@@ -635,7 +636,11 @@
           // Ugly hack to make the particle mesh always draw last
           scene.remove( mesh ); scene.add( mesh );
 
-          remainder = t - lastTime;
+          // Unless asked not to, accumulate the remainder of time for the next frame.
+          // Flag acts as a sort of regression test for http://crbug.com/883871 .
+          if (!skipRemainder)
+            remainder = t - lastTime;
+
           // If requestAnimationFrame timestamp jumps a lot, reset it.
           simulationShader.setTime(t);
         }

--- a/index.html
+++ b/index.html
@@ -598,6 +598,7 @@
 
       var frameId = 0;
       var fixedStep = 16.666666;
+      var remainder = 0;
       function render(t) {
         effect.requestAnimationFrame( render );
 
@@ -614,7 +615,7 @@
             lastTime = t - fixedStep;
           }
 
-          while (t - lastTime >= fixedStep) {
+          while (remainder + t - lastTime >= fixedStep) {
             lastTime += fixedStep;
             simulationShader.setTime(lastTime);
 
@@ -634,6 +635,7 @@
           // Ugly hack to make the particle mesh always draw last
           scene.remove( mesh ); scene.add( mesh );
 
+          remainder = t - lastTime;
           // If requestAnimationFrame timestamp jumps a lot, reset it.
           simulationShader.setTime(t);
         }


### PR DESCRIPTION
If the browser's requestAnimationFrame timestamps were exactly 16.667
ms apart, the demo would stop updating. See http://crbug.com/883871 .